### PR TITLE
feat(mdnDocs): make docs search better

### DIFF
--- a/src/interactions/mdnDocs.ts
+++ b/src/interactions/mdnDocs.ts
@@ -3,6 +3,7 @@ import { Response } from 'polka';
 import { logger } from '../util/logger';
 import { prepareErrorResponse, prepareResponse } from '../util/respond';
 import { encode } from 'querystring';
+import type { MDNResponse } from '../types/Interfaces';
 
 const API_BASE = 'https://developer.mozilla.org';
 const MDN_ICON = '<:mdn:818272565419573308>';
@@ -14,8 +15,12 @@ export async function mdnSearch(res: Response, query: string, target?: string): 
 		const qString = `${API_BASE}/api/v1/search?${encode({ q: query })}`;
 		let hit = cache.get(qString);
 		if (!hit) {
-			const result = await fetch(qString).then(r => r.json());
-			hit = result.documents?.[0];
+			const result: MDNResponse = await fetch(qString).then(r => r.json());
+			const docs = result.documents;
+			if (docs.length) {
+				hit = docs.find(doc => doc.title === query);
+				if (!hit) hit = docs[0];
+			}
 			cache.set(qString, hit);
 		}
 

--- a/src/types/Interfaces.ts
+++ b/src/types/Interfaces.ts
@@ -1,0 +1,17 @@
+export interface MDNResponse {
+	documents: Array<ResponseDocument>;
+	metadata: any;
+	suggestions: any;
+}
+
+export interface ResponseDocument {
+	mdn_url: string;
+	score: number;
+	title: string;
+	locale: string;
+	slug: string;
+	popularity: number;
+	archived: boolean;
+	summary: string;
+	highlight: any;
+}


### PR DESCRIPTION
Currently, bot returns the first element of the response array. Due to the nature of the API, sometimes what the user wants can be anywhere in the array. This PR adds a check in place that searches for the query string in the array and if not found returns the first element like earlier. I added some interfaces for the API response. They aren't complete because I only defined stuff that we needed. Now, the user will get what they want no matter where the response is in the array provided they know exactly what they are searching for, whch wasn't the case earlier.

⚠️ Thinks you should know:
- Since, the repo is really complicated I wasn't able to test this change but I did test it on my bot and it worked like it should.
- The query `Logical OR (||)` which started all of this, returns text that contains a pair of `||` in it, which discord renders as spoiler.